### PR TITLE
Use PAR and SAR to recalculate the mp4 derivative size to avoid vertical stretching. DAMSKEY-568

### DIFF
--- a/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
+++ b/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
@@ -2804,23 +2804,51 @@ public class DAMSAPIServlet extends HttpServlet
 					String scale = "scale=iw*min(" + sizewh[0] + "/iw\\," + sizewh[1] + "/ih):ih*min(" + sizewh[0] + "/iw\\," + sizewh[1] + "/ih)";
 					String pad = "pad=" + sizewh[0] + ":" + sizewh[1] + ":(" + sizewh[0] + "-iw*min(" + sizewh[0] + "/iw\\," + sizewh[1] + "/ih))/2:(" + sizewh[1] + "-ih*min(" + sizewh[0] + "/iw\\," + sizewh[1] + "/ih))/2";
 
-					Map<String, String> streamInfoMap = FfmpegUtil.executeInquiry(fs.getPath(objid, cmpid, fileid), ffmpegCommand);
+					String srcPath = fs.getPath(objid, cmpid, fileid);
+					Map<String, String> streamInfoMap = FfmpegUtil.executeInquiry(srcPath, ffmpegCommand);
 					// extract aspect ratio, frame size
 					String dar = streamInfoMap.get("dar");
-					String srcSize = streamInfoMap.get("size");
-					if (StringUtils.isNotBlank(dar)) {
-							codecParams += " -aspect " + dar;
-					}
+					String sar = streamInfoMap.get("sar");
+					String srcFrameSize = streamInfoMap.get("size");
 
 					if (derid.endsWith(derivativesExt)) {
 						// params to create jpeg thumbnails
 						codecParams += " -vf thumbnail," + scale + " -vframes 1";
 					} else {
 						// params to create video derivatives
+						if (StringUtils.isNotBlank(dar) && StringUtils.isNotBlank(sar) && StringUtils.isNotBlank(srcFrameSize) && !sar.equals("1:1")) {
+							// recalculate scale and padding when sar is not 1:1
+							String[] darWH = dar.split(":");
+							String[] sarWH = sar.split(":");
+
+							// display aspect ratio
+							int darW = Integer.parseInt(darWH[0]);
+							int darH = Integer.parseInt(darWH[1]);
+
+							// sample aspect ratio
+							int sarW = Integer.parseInt(sarWH[0]);
+							int sarH = Integer.parseInt(sarWH[1]);
+
+							// derivative frame size
+							int sizeW = Integer.parseInt(sizewh[0]);
+							int sizeH = Integer.parseInt(sizewh[1]);
+
+							// use PAR=DAR/SAR to recalculate the mp4 video size for stretched videos
+							double diff = darH*sarW*sizeW/((double)darW*sarH*sizeH) - darW*sarH*sizeH/((double)darH*sarW*sizeW);
+							long derIW = diff > 0 ? (int)Math.floor(darW*sarH*sizeH/((double)darH*sarW)) : sizeW;
+							long derIH = diff > 0 ? sizeH : (int)Math.floor(darH*sarW*sizeW/((double)darW*sarH));
+
+							scale = "setsar=1:1,scale=" + derIW + ":" + derIH;
+							pad = "pad=" + sizeW + ":" + sizeH + ":" + (derIW < sizeW ? (sizeW - derIW)/2 : "0") +":" + (derIH < sizeH ? (sizeH - derIH)/2 : "0");
+						} else if (StringUtils.isNotBlank(dar)) {
+							// enforce aspect ratio for videos that has sar=1:1
+							codecParams += " -aspect " + dar;
+						}
+
 						codecParams += " -vf yadif," + scale + "," + pad;
 					}
 			
-					log.info("FFMPEG codecParams: "  + codecParams);
+					log.info("FFMPEG video " + srcPath + " codecParams: "  + codecParams);
 					successful = ffmpeg.createDerivative(fs, objid, cmpid, fileid, derid, codecParams, paramSkip);
 				}
 				else

--- a/src/java/edu/ucsd/library/dams/jhove/FfmpegUtil.java
+++ b/src/java/edu/ucsd/library/dams/jhove/FfmpegUtil.java
@@ -94,6 +94,17 @@ public class FfmpegUtil
 						}
 					}
 
+					idx = line.indexOf("SAR ");
+					if (idx >= 0)
+					{
+						// extract aspect ratio
+						int endIdx = line.indexOf(' ', idx) > 0 ? line.indexOf(' ', idx + 4) : line.indexOf(',', idx);
+						if (endIdx > 0) {
+							String dar = line.substring(idx + 4, endIdx).trim();
+							fieldMap.put( "sar", dar );
+						}
+					}
+					
 					String s = line.replaceAll("\\[.+?\\]","");
 					s = s.replaceAll("\\(\\w+? / \\w+?\\)","");
 					s = s.replaceAll(".*Video:","");
@@ -108,6 +119,10 @@ public class FfmpegUtil
 							if ( qual.length() > 0 ) { qual += ", "; }
 							qual += tokens[i].trim();
 						}
+
+						// frame size
+						if (tokens[i].trim().matches("\\d+x\\d+"))
+							fieldMap.put( "size", tokens[i].trim() );
 					}
 					fieldMap.put( "video", qual );
 				}


### PR DESCRIPTION
https://lib-jira.ucsd.edu:8443/browse/DAMSKEY-568
