### PR TITLE
Update initial servlet size for file downloads.

### DIFF
--- a/src/webinf/web.xml
+++ b/src/webinf/web.xml
@@ -24,6 +24,7 @@
   <servlet>
     <servlet-name>DAMSAPIServlet</servlet-name>
     <servlet-class>edu.ucsd.library.dams.api.DAMSAPIServlet</servlet-class>
+    <load-on-startup>20</load-on-startup>
   </servlet>
   <servlet>
     <servlet-name>FedoraAPIServlet</servlet-name>
@@ -32,6 +33,7 @@
   <servlet>
     <servlet-name>FileStoreServlet</servlet-name>
     <servlet-class>edu.ucsd.library.dams.api.FileStoreServlet</servlet-class>
+    <load-on-startup>20</load-on-startup>
   </servlet>
   <servlet>
     <servlet-name>SimpleMinterServlet</servlet-name>


### PR DESCRIPTION
Update the initial servlet size to 20 to speed up the first damspas search result page loading for file downloads.