### PR TITLE
Fix the recurring broken images bug

### DIFF
--- a/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
+++ b/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
@@ -249,9 +249,7 @@ public class DAMSAPIServlet extends HttpServlet
 
 	// number detection
 	private static Pattern numberPattern = null;
-	private static SimpleDateFormat dateFormat = new SimpleDateFormat(
-		"yyyy-MM-dd'T'hh:mm:ssZ"
-	);
+	private static String dateFormat = "yyyy-MM-dd'T'hh:mm:ssZ";
 
 	// ldap for group lookup
 	private LDAPUtil ldaputil;
@@ -4429,7 +4427,7 @@ public class DAMSAPIServlet extends HttpServlet
 		Map info = new LinkedHashMap();
 		info.put( "statusCode", statusCode );
 		info.put( "message", msg );
-        info.put( "timestamp", dateFormat.format(new Date()) );
+        info.put( "timestamp", new SimpleDateFormat(dateFormat).format( new Date()) );
 		return info;
 	}
 
@@ -5033,7 +5031,7 @@ public class DAMSAPIServlet extends HttpServlet
 		props.put("mimeType", data.getMimeType());
 		props.put("formatName", data.getFormat());
 		props.put("formatVersion", data.getVersion());
-		props.put("dateCreated", dateFormat.format(data.getDateModified()));
+		props.put("dateCreated", new SimpleDateFormat(dateFormat).format(data.getDateModified()));
 		props.put("quality", data.getQuality());
 		props.put("duration", data.getDuration());
 		props.put("sourceFileName", data.getFileName());

--- a/src/java/edu/ucsd/library/dams/api/FedoraAPIServlet.java
+++ b/src/java/edu/ucsd/library/dams/api/FedoraAPIServlet.java
@@ -124,7 +124,7 @@ TXT DELETE /objects/[oid]/datastreams/[fid] (ts/arr) fileDelete
 	private static Logger log = Logger.getLogger(FedoraAPIServlet.class);
 
 	// date format
-	private static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+	private static String dateFormat = "yyyy-MM-dd";
 
 	private static String VISIBILITY_LOCAL = "local";
 	private static String VISIBILITY_PUBLIC_DOMAIN = "public domain";
@@ -1122,7 +1122,7 @@ TXT DELETE /objects/[oid]/datastreams/[fid] (ts/arr) fileDelete
 	// check whether a permission/restriction is current
 	private static boolean currentDates( Element e )
 	{
-		String currDate = dateFormat.format( new Date() );
+		String currDate = new SimpleDateFormat(dateFormat).format( new Date() );
 		String begin = e.valueOf("dams:beginDate");
 		String end = e.valueOf("dams:endDate");
 		

--- a/src/java/edu/ucsd/library/dams/file/FileStoreUtil.java
+++ b/src/java/edu/ucsd/library/dams/file/FileStoreUtil.java
@@ -80,12 +80,12 @@ public class FileStoreUtil
 	{
 		if ( s == null ) { return null; }
 		String result = "";
-		for( int i = 0; i < (s.length() - 1); i += 2 )
-		{
-			result += s.substring(i,i+2);
-			result += "/";
+		String leftOver = s;
+		while(leftOver.length() > 2) {
+			result += leftOver.substring(0, 2) + "/";
+			leftOver = leftOver.substring(2);
 		}
-		return result;
+		return result + leftOver + "/";
 	}
 
 	/**

--- a/src/java/edu/ucsd/library/dams/file/FileStoreUtil.java
+++ b/src/java/edu/ucsd/library/dams/file/FileStoreUtil.java
@@ -13,6 +13,7 @@ import java.lang.reflect.InvocationTargetException;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import edu.ucsd.library.dams.file.impl.LocalStore;
@@ -197,5 +198,15 @@ public class FileStoreUtil
         }
         catch ( Exception ex ) { throw new FileStoreException(ex); }
 		return bytesRead;
+    }
+
+    /**
+     * Construct file uri
+     * @param oid [String] object ark
+     * @param cid [String] component id
+     * @param fid [String] file id
+     */
+    public static String getFileUri(String oid, String cid, String fid) {
+        return "/" + oid + "/" + (StringUtils.isNotBlank(cid) ? cid + "/" : "") + fid;
     }
 }

--- a/src/test/edu/ucsd/library/dams/unitTest/file/FileStoreUtilTest.java
+++ b/src/test/edu/ucsd/library/dams/unitTest/file/FileStoreUtilTest.java
@@ -1,0 +1,22 @@
+package edu.ucsd.library.dams.unitTest.file;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import edu.ucsd.library.dams.file.FileStoreUtil;
+
+/**
+ * Test methods for FileStoreUtils class
+ * @author lsitu
+ *
+ */
+public class FileStoreUtilTest {
+
+    @Test
+    public void testPairPath() throws Exception {
+        assertEquals("Wrong pair path!", "bb/12/34/56/78/", FileStoreUtil.pairPath("bb12345678"));
+        assertEquals("Wrong pair path!", "bb/12/34/56/7/", FileStoreUtil.pairPath("bb1234567"));
+        assertEquals("Wrong pair path!", "b/", FileStoreUtil.pairPath("b"));
+    }
+}


### PR DESCRIPTION
Fixes #88 

Fixed the non-thread safe SimpleDateFromat that could cause the ArrayIndexOutOfBoundException. 
Reimplement the pairPath method to avoid missing characters issue.
Added logging for file retrieval.

@mcritchlow / @ucsdlib/developers Please review and comments ...