### PR TITLE
Update http to https in Mint DOI function

### DIFF
--- a/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
+++ b/src/java/edu/ucsd/library/dams/api/DAMSAPIServlet.java
@@ -3424,7 +3424,7 @@ public class DAMSAPIServlet extends HttpServlet
 
 		// mint doi
 		String doi = ezid.mintDOI( targetUrl, datacite );
-		String doiURL = doi.replaceAll("doi:","http://doi.org/");
+		String doiURL = doi.replaceAll("doi:","https://doi.org/");
 		log.info("Minted DOI: " + doiURL + " for " + targetUrl);
 
 		// add doi to object


### PR DESCRIPTION
Fixes #103 

Update http to https in Mint DOI function.  It has been deployed to staging. 
For example
https://librarytest.ucsd.edu/dc/object/bb11995109 uses https for Newly Mint DOI function

@ucsdlib/developers - please review