### PR TITLE
Stop counting subcollections in a collection's extent count

### DIFF
--- a/src/java/edu/ucsd/library/dams/model/DAMSObject.java
+++ b/src/java/edu/ucsd/library/dams/model/DAMSObject.java
@@ -506,7 +506,7 @@ public class DAMSObject
 			List<Identifier> linkedCols = new ArrayList<Identifier>();
 			linkedCollections( id, linkedCols );
 
-			Set<Identifier> allMembers = memberObjects(id);
+			Set<Identifier> allMembers = new HashSet<Identifier>();
 			for ( int i = 0; i < linkedCols.size(); i++ )
 			{
 				Identifier colid = linkedCols.get(i);


### PR DESCRIPTION
Reference #107 

Stop counting sub-collections in a parent collection's extent count.

@mcritchlow @ucsdlib/developers Please review.